### PR TITLE
Fix searchFilter escape error

### DIFF
--- a/examples/dynamic-conf/ldapAuth-conf.toml
+++ b/examples/dynamic-conf/ldapAuth-conf.toml
@@ -1,8 +1,11 @@
 [http.middlewares]
-  [http.middlewares.my-ldapAuth.plugin.ldapAuth]
-    Enabled = "true"
-    LogLevel = "DEBUG"
-    Url = "ldap://ldap.forumsys.com"
-    Port = "389"
-    BaseDN = "dc=example,dc=com"
-    Attribute = "uid"
+[http.middlewares.my-ldapAuth.plugin.ldapAuth]
+Attribute = "uid"
+BaseDN = "dc=example,dc=com"
+Enabled = "true"
+LogLevel = "DEBUG"
+Port = "389"
+Url = "ldap://ldap.forumsys.com"
+# SearchFilter must escape curly braces when using toml file
+# https://toml.io/en/v1.0.0#string
+# SearchFilter = '''(\{\{.Attribute\}\}=\{\{.Username\}\})'''

--- a/examples/dynamic-conf/ldapAuth-conf.yml
+++ b/examples/dynamic-conf/ldapAuth-conf.yml
@@ -9,3 +9,6 @@ http:
           Port: 389
           BaseDN: "dc=example,dc=com"
           Attribute: "uid"
+          # SearchFilter must escape curly braces when using yml file
+          # https://yaml.org/spec/1.1/#id872840
+          # SearchFilter: (\{\{.Attribute\}\}=\{\{.Username\}\})

--- a/ldapauth.go
+++ b/ldapauth.go
@@ -260,6 +260,7 @@ func ParseSearchFilter(config *Config) (string, error) {
 	filter = strings.Trim(filter, "\n\t")
 	filter = strings.TrimSpace(filter)
 	filter = strings.ReplaceAll(filter, " ", "")
+	filter = strings.Replace(filter, "\\", "", -1)
 
 	tmpl, err := template.New("search_template").Parse(filter)
 	if err != nil {

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,11 @@ For example: `(&(objectClass=inetOrgPerson)(gidNumber=500)({{.Attribute}}={{.Use
 
 Will be replaced to: `(&(objectClass=inetOrgPerson)(gidNumber=500)(uid=tesla))`.
 
-Note: All filters options must be start with Uppercase to be replaced correctly.
+Note1: All filters options must be start with Uppercase to be replaced correctly.
+
+Note2: `searchFilter` must escape curly braces when using [yml file](examples/dynamic-conf/ldapAuth-conf.yml).
+
+Note3: `searchFilter` must escape curly braces when using [toml file](examples/dynamic-conf/ldapAuth-conf.toml).
 
 ##### `baseDN`
 *Required, Default: `""`*


### PR DESCRIPTION
- Fixes #9
- Remove parsed characteres from ParseSearchFilter
- Add examples of how to escape characters to toml and yml file