### PR TITLE
Add support to Allowed Groups

### DIFF
--- a/examples/conf-from-labels.yml
+++ b/examples/conf-from-labels.yml
@@ -4,7 +4,7 @@ services:
   traefik:
     # build:
     #   context: .
-    image: traefik:v2.5.5
+    image: traefik:v2.8.2
     container_name: "traefik"
     command:
       #- "--log.level=DEBUG"
@@ -39,6 +39,7 @@ services:
       - traefik.http.middlewares.ldap_auth.plugin.ldapAuth.port=389
       - traefik.http.middlewares.ldap_auth.plugin.ldapAuth.baseDN=dc=example,dc=com
       - traefik.http.middlewares.ldap_auth.plugin.ldapAuth.attribute=uid
+      # AllowedGroups is not supported with labels, because multiple value labels are separated with commas
       # SearchFilter must not escape curly braces when using labels
       # - traefik.http.middlewares.ldap_auth.plugin.ldapAuth.searchFilter=({{.Attribute}}={{.Username}})
       # =================================================================================================

--- a/examples/conf-from-toml-file.yml
+++ b/examples/conf-from-toml-file.yml
@@ -5,7 +5,7 @@ services:
   traefik:
     # build:
     #   context: .
-    image: traefik:v2.5.5
+    image: traefik:v2.8.2
     container_name: "traefik"
     command:
       #- "--log.level=DEBUG"

--- a/examples/conf-from-yml-file.yml
+++ b/examples/conf-from-yml-file.yml
@@ -5,7 +5,7 @@ services:
   traefik:
     # build:
     #   context: .
-    image: traefik:v2.5.5
+    image: traefik:v2.8.2
     container_name: "traefik"
     command:
       #- "--log.level=DEBUG"

--- a/examples/dynamic-conf/ldapAuth-conf.toml
+++ b/examples/dynamic-conf/ldapAuth-conf.toml
@@ -6,6 +6,7 @@ Enabled = "true"
 LogLevel = "DEBUG"
 Port = "389"
 Url = "ldap://ldap.forumsys.com"
+AllowedGroups = ["ou=mathematicians,dc=example,dc=com","ou=italians,ou=scientists,dc=example,dc=com"]
 # SearchFilter must escape curly braces when using toml file
 # https://toml.io/en/v1.0.0#string
 # SearchFilter = '''(\{\{.Attribute\}\}=\{\{.Username\}\})'''

--- a/examples/dynamic-conf/ldapAuth-conf.yml
+++ b/examples/dynamic-conf/ldapAuth-conf.yml
@@ -9,6 +9,9 @@ http:
           Port: 389
           BaseDN: "dc=example,dc=com"
           Attribute: "uid"
+          AllowedGroups:
+            - ou=mathematicians,dc=example,dc=com
+            - ou=italians,ou=scientists,dc=example,dc=com
           # SearchFilter must escape curly braces when using yml file
           # https://yaml.org/spec/1.1/#id872840
           # SearchFilter: (\{\{.Attribute\}\}=\{\{.Username\}\})

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -356,3 +356,18 @@ You should got the `LDAP` related error:
 401 Unauthorized
 Error: [LDAP Result Code 49 "Invalid Credentials": ]
 ```
+
+If the user doesn't belong to any of `AllowedGroups`:
+
+```bash
+curl --user einstein:password \
+  -H "Host: whoami.localhost" \
+  http://0.0.0.0
+```
+
+You should got the `LDAP` related error:
+
+```text
+401 Unauthorized
+Error: [User not in any of the allowed groups]
+```

--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ LDAP server port where queries will be performed.
 
 _Optional, Default: `cn`_
 
-The attribute used to bind a user in [`Bind Mode`](#bind-mode). Bind queries use this pattern: `<attribute>=<username>,<baseDN>`, where the username is extracted from the request header.
+The attribute used to bind a user in [`Bind Mode`](#bind-mode). Bind queries use this pattern: `<attribute>=<username>,<baseDN>`, where the username is extracted from the request header. If [`AllowedGroups`](#allowedGroups) option was used in [`Bind Mode`](#bind-mode), the same pattern is added when searching if the user belongs to group.
 
 ##### `searchFilter`
 
@@ -217,3 +217,11 @@ If the LDAP middleware receives a request with a missing or invalid Authorizatio
 _Optional, Default: `""`_
 
 The name of the realm to specify in the `WWW-Authenticate` header. This option is ineffective unless the `wwwAuthenticateHeader` option is set to true.
+
+##### `allowedGroups` needs `traefik` >= [`v2.8.2`](https://github.com/traefik/traefik/releases/tag/v2.8.2)
+
+_Optional, Default: `[]`_
+
+The list of LDAP group DNs that users must be members of to be granted access. If a user is in any one of the listed groups, then that user is granted access.
+
+If setted to an empty list will allow all users that have an LDAP account to log in, without performing any group membership checks.


### PR DESCRIPTION
The list of LDAP group DNs that users must be members of to be granted access.
If a user is in any one of the listed groups, then that user is granted access.

If setted to an empty list will allow all users that have an LDAP account to
log in, without performing any group membership checks.

Fixes #3