### PR TITLE
support AD nested groups

### DIFF
--- a/ldapauth.go
+++ b/ldapauth.go
@@ -268,7 +268,8 @@ func LdapCheckUserGroups(conn *ldap.Conn, config *Config, entry *ldap.Entry, use
 			"(member=%s)"+
 			"(uniqueMember=%s)"+
 			"(memberUid=%s)"+
-			")", ldap.EscapeFilter(entry.DN), ldap.EscapeFilter(entry.DN), ldap.EscapeFilter(username))
+			"(member:1.2.840.113556.1.4.1941:=%s)"+
+			")", ldap.EscapeFilter(entry.DN), ldap.EscapeFilter(entry.DN), ldap.EscapeFilter(username), ldap.EscapeFilter(entry.DN))
 
 		LoggerDEBUG.Printf("Searching Group: '%s' with User: '%s'", g, entry.DN)
 


### PR DESCRIPTION
Simply added the [LDAP_MATCHING_RULE_IN_CHAIN](https://learn.microsoft.com/en-us/windows/win32/adsi/search-filter-syntax
) (1.2.840.113556.1.4.1941) to the OR clause of the group filter. This allows searches across nested Active Directory groups as opposed direct members only.