### PR TITLE
Fix content type on errors

### DIFF
--- a/ldapauth.go
+++ b/ldapauth.go
@@ -309,7 +309,7 @@ func LdapCheckUserGroups(conn *ldap.Conn, config *Config, entry *ldap.Entry, use
 // RequireAuth set Auth request.
 func RequireAuth(w http.ResponseWriter, req *http.Request, config *Config, err ...error) {
 	LoggerDEBUG.Println(err)
-	w.Header().Set("Content-Type", "text/plan")
+	w.Header().Set("Content-Type", "text/plain")
 	if config.WWWAuthenticateHeader {
 		wwwHeaderContent := "Basic"
 		if config.WWWAuthenticateHeaderRealm != "" {

--- a/ldapauth.go
+++ b/ldapauth.go
@@ -317,8 +317,11 @@ func RequireAuth(w http.ResponseWriter, req *http.Request, config *Config, err .
 		}
 		w.Header().Set("WWW-Authenticate", wwwHeaderContent)
 	}
+
 	w.WriteHeader(http.StatusUnauthorized)
-	_, _ = w.Write([]byte(fmt.Sprintf("%d %s\nError: %s\n", http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), err)))
+
+	errMsg := strings.Trim(err[0].Error(), "\x00")
+	_, _ = w.Write([]byte(fmt.Sprintf("%d %s\nError: %s\n", http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), errMsg)))
 }
 
 // Connect return a LDAP Connection.


### PR DESCRIPTION
This a follow-up PR to a request I had made to the go-ldap project. Their view is that my change should go in the end project rather than theirs.

Active Directory errors are returned with a trailing nul character (0x00). When the plugin returns a 401 with the error details, it causes web browsers to interpret the content as binary and attempt to download it as a file. This PR simply strips the nul character and fixes a typo in the Content-Type header.

For more details, you can look at the PR I had open with the go-ldap project [here](https://github.com/go-ldap/ldap/pull/437).