### PR TITLE
feat: add support for allowing individual users

### DIFF
--- a/examples/conf-from-labels.yml
+++ b/examples/conf-from-labels.yml
@@ -38,7 +38,7 @@ services:
       - traefik.http.middlewares.ldap_auth.plugin.ldapAuth.port=389
       - traefik.http.middlewares.ldap_auth.plugin.ldapAuth.baseDN=dc=example,dc=com
       - traefik.http.middlewares.ldap_auth.plugin.ldapAuth.attribute=uid
-      # AllowedGroups is not supported with labels, because multiple value labels are separated with commas
+      # AllowedGroups and AllowedUsers are not supported with labels, because multiple value labels are separated with commas
       # SearchFilter must not escape curly braces when using labels
       # - traefik.http.middlewares.ldap_auth.plugin.ldapAuth.searchFilter=({{.Attribute}}={{.Username}})
       # =================================================================================================

--- a/examples/dynamic-conf/ldapAuth-conf.toml
+++ b/examples/dynamic-conf/ldapAuth-conf.toml
@@ -7,6 +7,7 @@ LogLevel = "DEBUG"
 Port = "389"
 Url = "ldap://ldap.forumsys.com"
 AllowedGroups = ["ou=mathematicians,dc=example,dc=com","ou=italians,ou=scientists,dc=example,dc=com"]
+AllowedUsers = ["euler", "euclid"]
 # SearchFilter must escape curly braces when using toml file
 # https://toml.io/en/v1.0.0#string
 # SearchFilter = '''(\{\{.Attribute\}\}=\{\{.Username\}\})'''

--- a/examples/dynamic-conf/ldapAuth-conf.yml
+++ b/examples/dynamic-conf/ldapAuth-conf.yml
@@ -12,6 +12,9 @@ http:
           AllowedGroups:
             - ou=mathematicians,dc=example,dc=com
             - ou=italians,ou=scientists,dc=example,dc=com
+          AllowedUsers:
+            - euler
+            - euclid
           # SearchFilter must escape curly braces when using yml file
           # https://yaml.org/spec/1.1/#id872840
           # SearchFilter: (\{\{.Attribute\}\}=\{\{.Username\}\})

--- a/readme.md
+++ b/readme.md
@@ -278,6 +278,17 @@ _Optional, Default: `[]`_
 
 The list of LDAP group DNs that users must be members of to be granted access. If a user is in any of the listed groups, then that user is granted access.
 
-If set to an empty list, all users with an LDAP account can log in, without performing any group membership checks.
+If set to an empty list, all users with an LDAP account can log in, without performing any group membership checks unless `allowedUsers` is set. In that case, the user must be a part of the `allowedUsers` list.
 
 `allowedGroups` is not supported with labels, because multiple value labels are separated with commas. You must use `toml` or `yaml` configuration file. For more details, check [examples](https://github.com/wiltonsr/ldapAuth/tree/main/examples) page.
+
+##### `allowedUsers`
+Needs `traefik` >= [`v2.8.2`](https://github.com/traefik/traefik/releases/tag/v2.8.2)
+
+_Optional, Default: `[]`_
+
+The list of LDAP user DNs or usernames to be granted access. If a user is in the listed users, then that user is granted access.
+
+If set to an empty list, all users with an LDAP account can log in, unless `allowedGroups` is set. In that case, group membership checks will be performed.
+
+`allowedUsers` is not supported with labels, because multiple value labels are separated with commas. You must use `toml` or `yaml` configuration file. For more details, check [examples](https://github.com/wiltonsr/ldapAuth/tree/main/examples) page.


### PR DESCRIPTION
Hello,

I have a use case where I would like to authorize service accounts without necessarily adding them to security groups. I implemented a new feature in the plugin to support granting access to users via either DNs or usernames. It is very similar to the AllowedGroups feature except that no LDAP queries are required.

Added:
* LdapCheckAllowedUsers: Returns true if the user to authorize is part of the AllowedUsers list (DN or username) or false if the list is empty.
* LdapCheckUserAuthorized: Handles the authorization flow post-authentication. It checks if either AllowedUsers or AllowedGroups is set. If both are not, returns true. Otherwise, it checks both the AllowedUsers and AllowedGroups.
* Documentation for AllowedUsers feature
* Added AllowedUsers to examples as well

Minor changes:
* LdapCheckUserGroups returns errrors only for unexpected behaviours (LDAP issues basically). It also returns false, if the list of Allowed groups is empty.
* ServeHTTP: It nows leverages the newly added LdapCheckUserAuthorized function instead of using LdapCheckUserGroups directly.

[No breaking changes]