### PR TITLE
add extra cookie options

### DIFF
--- a/ldapauth.go
+++ b/ldapauth.go
@@ -43,6 +43,8 @@ type Config struct {
 	Port                       uint16   `json:"port,omitempty" yaml:"port,omitempty"`
 	CacheTimeout               uint32   `json:"cacheTimeout,omitempty" yaml:"cacheTimeout,omitempty"`
 	CacheCookieName            string   `json:"cacheCookieName,omitempty" yaml:"cacheCookieName,omitempty"`
+	CacheCookiePath            string   `json:"cacheCookiePath,omitempty" yaml:"cacheCookiePath,omitempty"`
+	CacheCookieSecure          bool     `json:"cacheCookieSecure,omitempty" yaml:"cacheCookieSecure,omitempty"`
 	CacheKey                   string   `json:"cacheKey,omitempty" yaml:"cacheKey,omitempty"`
 	UseTLS                     bool     `json:"useTls,omitempty" yaml:"useTls,omitempty"`
 	StartTLS                   bool     `json:"startTls,omitempty" yaml:"startTls,omitempty"`
@@ -73,6 +75,8 @@ func CreateConfig() *Config {
 		Port:                       389, // Usually 389 or 636
 		CacheTimeout:               300, // In seconds, default to 5m
 		CacheCookieName:            "ldapAuth_session_token",
+		CacheCookiePath:            "",
+		CacheCookieSecure:          false,
 		CacheKey:                   "super-secret-key",
 		UseTLS:                     false,
 		StartTLS:                   false,
@@ -113,7 +117,10 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 	// Create new session with CacheKey and CacheTimeout.
 	store = sessions.NewCookieStore([]byte(config.CacheKey))
 	store.Options = &sessions.Options{
-		MaxAge: int(config.CacheTimeout),
+		HttpOnly: true,
+		MaxAge:   int(config.CacheTimeout),
+		Path:     config.CacheCookiePath,
+		Secure:   config.CacheCookieSecure,
 	}
 
 	return &LdapAuth{

--- a/readme.md
+++ b/readme.md
@@ -138,18 +138,29 @@ LDAP server port where queries will be performed.
 ##### `cacheTimeout`
 _Optional, Default: `300`_
 
-Indicates the number of `seconds` until the cookie session expires. A zero or negative number will expire the cookie immediately. 
+Indicates the number of `seconds` until the session cookie expires. A zero or negative number will expire the cookie immediately. 
+
 ##### `cacheCookieName`
 _Optional, Default: `ldapAuth_session_token`_
 
-The cookie session name.
+The session cookie name.
+
+##### `cacheCookiePath`
+_Optional, Default: `""`_
+
+The session cookie path. By default, the cookie path will be set to the request path.
+
+##### `cacheCookieSecure`
+_Optional, Default: `false`_
+
+Set to true if the session cookie should have the secure flag. The cookie will only be transmitted over an HTTPS connection.
 
 ##### `cacheKey`
 Needs `traefik` >= [`v2.8.5`](https://github.com/traefik/traefik/releases/tag/v2.8.5)
 
 _Optional, Default: `super-secret-key`_
 
-The key used to cryptography cookie session information. You `must` use a strong value here.
+The key used to encrypt session cookie information. You `must` use a strong value here.
 
 ##### `useTLS`
 _Optional, Default: `false`_


### PR DESCRIPTION
Minor change to provide more security on the session cookie:

* Enforce HttpOnly on the cookie to protect it from potential XSS attacks
* Add support for `Secure`  flag on cookie
* Enable setting the path on cookie:

I noticed that if you authenticate on anything but on the "/" path, the cookie is created with that path. This leads to multiple cookies in the browser set to different paths. Setting the path to "/" fixes that.

Example:
1. Browse to my domain.com/app/static/image.jpg => Cookie Path: /app/static
2. Browse to my domain.com/app/static => Cookie Path: /app
3. Browse to my domain.com => Cookie Path: /

I think for most use cases, having the path on / would makes sense.