### PR TITLE
feat: allow usage of a environment variable or secret for sensitive params

### DIFF
--- a/ldapauth.go
+++ b/ldapauth.go
@@ -101,9 +101,6 @@ func CreateConfig() *Config {
 		CacheCookieSecure:          false,
 		CacheKey:                   defaultCacheKey,
 		CacheKeyLabel:              "LDAP_AUTH_CACHE_KEY",
-		StartTLS:                   false,
-		CertificateAuthority:       "",
-		InsecureSkipVerify:         false,
 		Attribute:                  "cn", // Usually uid or sAMAccountname
 		SearchFilter:               "",
 		BaseDN:                     "",

--- a/ldapauth.go
+++ b/ldapauth.go
@@ -726,10 +726,10 @@ func settingDefaults(config *Config) {
 
 // retrieve a secret value from environment variable or secret on the FS
 func getSecret(label string) string {
-	bindPassword := os.Getenv(strings.ToUpper(label))
+	secret := os.Getenv(strings.ToUpper(label))
 
-	if bindPassword != "" {
-		return bindPassword
+	if secret != "" {
+		return secret
 	}
 
 	b, err := os.ReadFile(fmt.Sprintf("/run/secrets/%s", strings.ToLower(label)))

--- a/ldapauth.go
+++ b/ldapauth.go
@@ -159,7 +159,6 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 
 	settingDefaults(config)
 
-	logConfigParams(config)
 	if config.BindDN != "" && config.BindPassword == "" {
 		config.BindPassword = getSecret(config.BindPasswordLabel)
 	}

--- a/ldapauth.go
+++ b/ldapauth.go
@@ -731,9 +731,15 @@ func getSecret(label string) string {
 		return secret
 	}
 
-	b, err := os.ReadFile(fmt.Sprintf("/run/secrets/%s", strings.ToLower(label)))
+	path := fmt.Sprintf("/run/secrets/%s", strings.ToLower(label))
+
+	if os.Getenv(strings.ToUpper(label)+"_FILE") != "" {
+		path = os.Getenv(strings.ToUpper(label) + "_FILE")
+	}
+
+	b, err := os.ReadFile(path)
 	if err != nil {
-		LoggerERROR.Printf("could not load secret %s: %s", label, err)
+		LoggerWARNING.Printf("could not load secret %s: %s", label, err)
 		return ""
 	}
 	return strings.TrimSpace(string(b))

--- a/ldapauth_test.go
+++ b/ldapauth_test.go
@@ -1,23 +1,22 @@
 // Package ldapAuth_test a test suit for ldap authentication plugin.
-//nolint
-package ldapAuth_test
+// nolint
+package ldapAuth
 
 import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
-
-	"github.com/wiltonsr/ldapAuth"
 )
 
 func TestDemo(t *testing.T) {
-	cfg := ldapAuth.CreateConfig()
+	cfg := CreateConfig()
 
 	ctx := context.Background()
 	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {})
 
-	handler, err := ldapAuth.New(ctx, next, cfg, "ldapAuth")
+	handler, err := New(ctx, next, cfg, "ldapAuth")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,10 +32,37 @@ func TestDemo(t *testing.T) {
 
 }
 
-func assertHeader(t *testing.T, req *http.Request, key, expected string) {
-	t.Helper()
+func TestGetSecret(t *testing.T) {
 
-	if req.Header.Get(key) != expected {
-		t.Errorf("invalid header value: %s", req.Header.Get(key))
+	t.Setenv("LDAP_AUTH_BIND_PASSWORD", "verysecret")
+
+	secret := getSecret("LDAP_AUTH_BIND_PASSWORD")
+	if secret != "verysecret" {
+		t.Fatal("secret should be loaded from env")
+	}
+
+	secret = getSecret("LDAP_AUTH_BIND_PASSWORD_NOT_SET")
+	if secret != "" {
+		t.Fatal("secret should be empty")
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Setenv("LDAP_AUTH_CACHE_KEY_FILE", ".\\mock\\secret")
+	} else {
+		t.Setenv("LDAP_AUTH_CACHE_KEY_FILE", "./mock/secret")
+	}
+
+	secret = getSecret("LDAP_AUTH_CACHE_KEY")
+
+	if secret != "this_is_a_secret" {
+		t.Fatal("secret should be loaded from file")
+	}
+
+	t.Setenv("ANOTHER_SECRET_FILE", "./mock/secret")
+	t.Setenv("ANOTHER_SECRET", "this_is_another_secret")
+
+	secret = getSecret("ANOTHER_SECRET")
+	if secret != "this_is_another_secret" {
+		t.Fatal("secret should be loaded from env and not from file")
 	}
 }

--- a/mock/secret
+++ b/mock/secret
@@ -1,0 +1,1 @@
+this_is_a_secret

--- a/readme.md
+++ b/readme.md
@@ -182,7 +182,9 @@ To be consistent with other traefik plugins, the environment variable should be 
 
 Example:
 cacheKeyLabel=my_cache_key_label
-The environment variable `MY_CACHE_KEY_LABEL` or a file containing the password should be mounted to `/run/secrets/my_cache_key_label`.
+The environment variable `MY_CACHE_KEY_LABEL` will be used.
+As an alternative to passing sensitive information via environment variables, _FILE may be appended to the environment variable, causing the configuration to load the value for this variable from the defined file present in the container. Default path value is `/run/secrets/my_cache_key_label`.
+
 Typically, with docker you can use a secret named `my_cache_key_label`.
 
 The environment variable will be used if both options are set.
@@ -290,7 +292,9 @@ To be consistent with other traefik plugins, the environment variable should be 
 
 Example:
 bindPasswordLabel=my_bind_password_label
-The environment variable `MY_BIND_PASSWORD_LABEL` or a file containing the password should be mounted to `/run/secrets/my_bind_password_label`.
+The environment variable `MY_BIND_PASSWORD_LABEL` will be used.
+As an alternative to passing sensitive information via environment variables, _FILE may be appended to the environment variable, causing the configuration to load the value for this variable from the defined file in the container. Default path value is `/run/secrets/my_bind_password_label`.
+
 Typically, with docker you can use a secret named `my_bind_password_label`.
 
 The environment variable will be used if both options are set.

--- a/readme.md
+++ b/readme.md
@@ -168,7 +168,24 @@ Needs `traefik` >= [`v2.8.5`](https://github.com/traefik/traefik/releases/tag/v2
 
 _Optional_
 
-The key used to sign session cookie information. If unset, one will be randomly generated at startup.
+The key used to encrypt session cookie information. You `must` use a strong value here.
+You can also use a secret or a environment variable, see `cacheKeyLabel`.
+
+
+#### `cacheKeyLabel`
+
+_Optional, Default: `"LDAP_AUTH_CACHE_KEY"`_
+
+Only used when `cacheKey` is not set.
+This allow the user to choose the name or the environment variable or the file name.
+To be consistent with other traefik plugins, the environment variable should be upper case, and file name lower case.
+
+Example:
+cacheKeyLabel=my_cache_key_label
+The environment variable `MY_CACHE_KEY_LABEL` or a file containing the password should be mounted to `/run/secrets/my_cache_key_label`.
+Typically, with docker you can use a secret named `my_cache_key_label`.
+
+The environment variable will be used if both options are set.
 
 ##### `serverList.startTLS`
 _Optional, Default: `false`_
@@ -262,6 +279,21 @@ The domain name to bind to in order to authenticate to the LDAP server when runn
 _Optional, Default: `""`_
 
 The password corresponding to the `bindDN` specified when running in [`Search Mode`](#search-mode), is used in order to authenticate to the LDAP server.
+You can also use a secret or a environment variable, see `bindPasswordLabel`.
+
+##### `bindPasswordLabel`
+_Optional, Default: `"LDAP_AUTH_BIND_PASSWORD"`_
+
+Only used when `bindDN` is not empty, and `bindPassword` is not set.
+This allow the user to choose the name or the environment variable or the file name.
+To be consistent with other traefik plugins, the environment variable should be upper case, and file name lower case.
+
+Example:
+bindPasswordLabel=my_bind_password_label
+The environment variable `MY_BIND_PASSWORD_LABEL` or a file containing the password should be mounted to `/run/secrets/my_bind_password_label`.
+Typically, with docker you can use a secret named `my_bind_password_label`.
+
+The environment variable will be used if both options are set.
 
 ##### `forwardUsername`
 


### PR DESCRIPTION
Hello,

Created this PR to solve issue #13.
Added possibility to set bindPassword from environment variable or docker secret (filesystem `/run/secrets/my_secret`).

No breaking change.