### PR TITLE
fix: replace html templating with text templating to avoid html escaping

### DIFF
--- a/ldapauth.go
+++ b/ldapauth.go
@@ -9,7 +9,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"html/template"
+	"text/template"
 	"io/ioutil"
 	"log"
 	"net"


### PR DESCRIPTION
#50 
@wiltonsr This should fix. It worked as intended for me