### PR TITLE
fix: also forward username on cached requests

### DIFF
--- a/ldapauth.go
+++ b/ldapauth.go
@@ -156,6 +156,13 @@ func (la *LdapAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if auth, ok := session.Values["authenticated"].(bool); ok && auth {
 		if session.Values["username"] == username {
 			LoggerDEBUG.Printf("Session token Valid! Passing request...")
+			
+			// also pass request username if configured to do so
+			if la.config.ForwardUsername {
+				req.URL.User = url.User(username)
+				req.Header[la.config.ForwardUsernameHeader] = []string{username}
+			}
+
 			la.next.ServeHTTP(rw, req)
 			return
 		}


### PR DESCRIPTION
Fixes #57

Ensures the ForwardUsername setting is honored also when the LDAP authentication was cached into the session variable.